### PR TITLE
Update quickstart with latest standards

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/python:3",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
   "features": {
     "ghcr.io/azure/azure-dev/azd": {},
     "ghcr.io/devcontainers/features/azure-cli": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "image": "mcr.microsoft.com/devcontainers/python:3",
   "features": {
-    "ghcr.io/devcontainers/features/azure-cli:1": {},
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/azure/azure-dev/azd:0": {}
+    "ghcr.io/azure/azure-dev/azd": {},
+    "ghcr.io/devcontainers/features/azure-cli": {},
+    "ghcr.io/devcontainers/features/docker-in-docker": {}
   },
   "customizations": {
     "vscode": {

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,7 +6,7 @@ jobs:
   validate-python:
     name: Validate Python solution
     runs-on: ubuntu-latest
-    container: python:3.11
+    container: python:3
     steps:
       - name: Checkout code
         uses: actions/checkout@v4     

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,7 +6,7 @@ jobs:
   validate-python:
     name: Validate Python solution
     runs-on: ubuntu-latest
-    container: python:3
+    container: python:3.12
     steps:
       - name: Checkout code
         uses: actions/checkout@v4     

--- a/azure.yaml
+++ b/azure.yaml
@@ -9,5 +9,3 @@ services:
     docker:
       path: ./Dockerfile
       context: ./
-pipeline:
-  provider: github

--- a/infra/app/web.bicep
+++ b/infra/app/web.bicep
@@ -39,6 +39,7 @@ module containerAppsApp '../core/host/container-apps/app.bicep' = {
         secretRef: 'azure-cosmos-db-nosql-endpoint' // Reference to secret
       }
     ]
+    targetPort: 8000
     enableSystemAssignedManagedIdentity: true
   }
 }

--- a/infra/app/web.bicep
+++ b/infra/app/web.bicep
@@ -39,7 +39,6 @@ module containerAppsApp '../core/host/container-apps/app.bicep' = {
         secretRef: 'azure-cosmos-db-nosql-endpoint' // Reference to secret
       }
     ]
-    targetPort: 8000
     enableSystemAssignedManagedIdentity: true
   }
 }

--- a/infra/core/host/container-apps/app.bicep
+++ b/infra/core/host/container-apps/app.bicep
@@ -8,7 +8,7 @@ param tags object = {}
 param parentEnvironmentName string
 
 @description('Specifies the docker container image to deploy.')
-param containerImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+param containerImage string = 'mcr.microsoft.com/k8se/quickstart:latest'
 
 @description('Specifies the container port.')
 param targetPort int = 80

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.12
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ COPY . .
 
 EXPOSE 8000
 
-ENV PORT 8000
-ENV DEBUG True
+ENV PORT=8000
+ENV DEBUG=True
 
-CMD gunicorn --worker-class eventlet --bind 0.0.0.0:8000 app:app
+CMD ["gunicorn", "--worker-class", "eventlet", "--bind", "0.0.0.0:8000", "app:app"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3
 
 WORKDIR /app
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 Flask==3.*
 Flask-SocketIO==5.*
-azure-cosmos==4.*
+azure-data-tables==12.*
 azure-identity==1.*
+gunicorn==23.*
 eventlet==0.*
-gunicorn==21.*

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 Flask==3.*
 Flask-SocketIO==5.*
-azure-data-tables==12.*
+azure-cosmos==4.*
 azure-identity==1.*
 gunicorn==23.*
 eventlet==0.*


### PR DESCRIPTION
- [x] Latest versioning for devcontainer features
- [x] Use latest Python 3.12 version instead of locked to a specific older version (3.11)
- [x] Removed pipeline provider
- [x] Removed ACA target port
- [x] Updated ACA placeholder image to `mcr.microsoft.com/k8se/quickstart:latest` 

> [!IMPORTANT]
> Gunicorn and `eventlet` are not compatible with Python 3.13 yet